### PR TITLE
[feat] 회원가입 시 유효성 검증

### DIFF
--- a/src/main/java/com/wanted/gold/exception/ConflictException.java
+++ b/src/main/java/com/wanted/gold/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package com.wanted.gold.exception;
+
+public class ConflictException extends BaseException {
+
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ConflictException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/wanted/gold/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/gold/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.wanted.gold.exception;
 
+import com.google.api.Http;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,6 +10,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 기본
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    // 회원가입
+    ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "이미 존재하는 username입니다."),
+    USERNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "6자리 이상 20자리 이하로 설정해주세요."),
+    USERNAME_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "영문 소문자, 숫자, 언더바(_)만 사용할 수 있습니다."),
+    USERNAME_CANNOT_ONLY_NUMBER(HttpStatus.BAD_REQUEST, "숫자로만 이루어질 수 없습니다."),
+    PASSWORD_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "10자리 이상으로 설정해주세요."),
+    PASSWORD_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "소문자, 숫자, 특수문자를 모두 포함해야 합니다. 포함할 수 있는 특수문자는 !@#$%^&* 입니다."),
 
     // 로그인
     INVALID_LOGIN_PARAMETER(HttpStatus.BAD_REQUEST, "username 또는 password가 빈 값인지 확인해주세요."),

--- a/src/main/java/com/wanted/gold/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/gold/exception/handler/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.wanted.gold.exception.handler;
 
-import com.wanted.gold.exception.BadRequestException;
-import com.wanted.gold.exception.ErrorResponse;
-import com.wanted.gold.exception.NotFoundException;
-import com.wanted.gold.exception.UnauthorizedException;
+import com.wanted.gold.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +24,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflictException(ConflictException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorCode().getMessage()));
     }
 }

--- a/src/main/java/com/wanted/gold/user/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/gold/user/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 // 세션 미사용
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/api/users/**").permitAll() // 어떤 사용자든 접근 가능
+                        .requestMatchers("/api/users/sign-up", "/api/users/login").permitAll() // 어떤 사용자든 접근 가능
                         .requestMatchers("/api/tokens/access-token").permitAll() // 액세스 토큰 재발급
                         .anyRequest().authenticated()) // 인증 필요
                 .exceptionHandling(e -> e

--- a/src/main/java/com/wanted/gold/user/dto/SignUpRequestDto.java
+++ b/src/main/java/com/wanted/gold/user/dto/SignUpRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequestDto(
-        @NotBlank @Size(max = 30) String username,
-        @NotBlank @Size(min = 10, max = 200, message = "최소 10자리 이상으로 설정해주세요.") String password
+        @NotBlank @Size(max = 20, message = "최소 6자리 이상으로 설정해주세요.") String username,
+        @NotBlank @Size(max = 200, message = "최소 10자리 이상으로 설정해주세요.") String password
 ) {
 }

--- a/src/main/java/com/wanted/gold/user/service/UserService.java
+++ b/src/main/java/com/wanted/gold/user/service/UserService.java
@@ -24,9 +24,12 @@ public class UserService {
     private final TokenRepository tokenRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final UserValidator userValidator;
 
     // 회원가입
     public SignUpResponseDto signUp(SignUpRequestDto requestDto) {
+        // username과 password 검증
+        userValidator.validateRequest(requestDto);
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(requestDto.password());
         // User 생성

--- a/src/main/java/com/wanted/gold/user/service/UserValidator.java
+++ b/src/main/java/com/wanted/gold/user/service/UserValidator.java
@@ -1,0 +1,49 @@
+package com.wanted.gold.user.service;
+
+import com.wanted.gold.exception.BadRequestException;
+import com.wanted.gold.exception.ConflictException;
+import com.wanted.gold.exception.ErrorCode;
+import com.wanted.gold.user.dto.SignUpRequestDto;
+import com.wanted.gold.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserValidator {
+    private final UserRepository userRepository;
+
+    // 회원가입 시 유효성 검사
+    public void validateRequest(SignUpRequestDto requestDto) {
+        // username 유효성 검사
+        validateUsername(requestDto.username());
+        // username 중복 확인
+        if(userRepository.findByUsername(requestDto.username()).isPresent())
+            throw new ConflictException(ErrorCode.ALREADY_EXIST_USERNAME);
+        // password 유효성 검사
+        validatePassword(requestDto.password());
+    }
+
+    // username 유효성 검사
+    public void validateUsername(String username) {
+        // 1. 길이가 6자리 미만이거나 20자리 초과일 경우
+        if(username.length() < 6 || username.length() > 20)
+            throw new BadRequestException(ErrorCode.USERNAME_LENGTH_INVALID);
+        // 2. 영문 소문자, 숫자, 언더바(_) 외 다른 문자가 포함된 경우
+        if(!username.matches("^[a-z0-9_]+$"))
+            throw new BadRequestException(ErrorCode.USERNAME_INVALID_CHARACTER);
+        // 3. 숫자로만 이루어졌을 경우
+        if(username.matches("^[0-9]+$"))
+            throw new BadRequestException(ErrorCode.USERNAME_CANNOT_ONLY_NUMBER);
+    }
+
+    // password 유효성 검사
+    public void validatePassword(String password) {
+        // 1. 길이가 10자리 미만일 경우
+        if(password.length() < 10)
+            throw new BadRequestException(ErrorCode.PASSWORD_LENGTH_INVALID);
+        // 2. 소문자, 숫자, 특수문자 중 하나라도 포함되지 않은 경우 - 포함되는 특수문자 !@#$%^&*
+        if (!password.matches(".*[a-z].*") || !password.matches(".*[0-9].*") || !password.matches(".*[!@#$%^&*].*"))
+            throw new BadRequestException(ErrorCode.PASSWORD_INVALID_CHARACTER);
+    }
+}


### PR DESCRIPTION
## Issue
- #13 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/signup_validation -> dev

## 변경 사항
### 회원가입 시 `username` 조건
1. 6자리 이상 20자리 이하
2. 영문 소문자, 숫자, 언더바(_)만 사용
3. 숫자로만 구성 금지
### 회원가입 시 `password` 조건
1. 10자리 이상
2. 소문자, 숫자, 특수문자 모두 포함 - 특수문자는 !@#$%^&*

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/users/sign-up
```
- **Request Body**
```
{
    "username": "ijiwon_123",
    "password": "ijiwon123!"
}
```

### Response : 성공시
`201 Created`
```
{
    "message": "회원가입이 완료되었습니다.",
    "username": "ijiwon_123"
}
```

### Response : 실패시
### `400 Bad Request`
1. `username` 길이가 6자리 미만이거나 20자리 초과일 경우
```
{
    "status": 400,
    "message": "6자리 이상 20자리 이하로 설정해주세요."
}
```

2. `username`에 영문 소문자, 숫자, 언더바(_) 외 다른 문자가 포함된 경우
```
{
    "status": 400,
    "message": "영문 소문자, 숫자, 언더바(_)만 사용할 수 있습니다."
}
```

3. `username`이 숫자로만 이루어졌을 경우
```
{
    "status": 400,
    "message": "숫자로만 이루어질 수 없습니다."
}
```

4. `password` 길이가 10자리 미만일 경우
```
{
    "status": 400,
    "message": "10자리 이상으로 설정해주세요."
}
```

5. `password`에 소문자, 숫자, 특수문자 중 하나라도 포함되지 않은 경우 - 포함되는 특수문자 !@#$%^&*
```
{
    "status": 400,
    "message": "소문자, 숫자, 특수문자를 모두 포함해야 합니다. 포함할 수 있는 특수문자는 !@#$%^&* 입니다."
}
```